### PR TITLE
Expose generic mypy error as a diagnostic

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,8 +38,8 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings
+        flake8 . --count --exit-zero --statistics
     - name: Check black formatting
       run: |
         # stop the build if black detect any changes

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,9 +37,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings
-        flake8 . --count --exit-zero --statistics
+        flake8 . --count --show-source --statistics
     - name: Check black formatting
       run: |
         # stop the build if black detect any changes

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -278,6 +278,22 @@ def pylsp_lint(
     log.debug("errors:\n%s", errors)
 
     diagnostics = []
+
+    # Expose generic mypy error on the first line.
+    if errors:
+        diagnostics.append(
+            {
+                "source": "mypy",
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    # Client is supposed to clip end column to line length.
+                    "end": {"line": 0, "character": 1000},
+                },
+                "message": errors,
+                "severity": 1,  # Error
+            }
+        )
+
     for line in report.splitlines():
         log.debug("parsing: line = %r", line)
         diag = parse_line(line, document)

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -207,6 +207,7 @@ def pylsp_lint(
         args.append("--strict")
 
     overrides = settings.get("overrides", [True])
+    exit_status = 0
 
     if not dmypy:
         args.extend(["--incremental", "--follow-imports", "silent"])
@@ -221,11 +222,12 @@ def pylsp_lint(
             )
             report = completed_process.stdout.decode()
             errors = completed_process.stderr.decode()
+            exit_status = completed_process.returncode
         else:
             # mypy does not exist on path, but must exist in the env pylsp-mypy is installed in
             # -> use mypy via api
             log.info("executing mypy args = %s via api", args)
-            report, errors, _ = mypy_api.run(args)
+            report, errors, exit_status = mypy_api.run(args)
     else:
         # If dmypy daemon is non-responsive calls to run will block.
         # Check daemon status, if non-zero daemon is dead or hung.
@@ -239,20 +241,20 @@ def pylsp_lint(
             completed_process = subprocess.run(
                 ["dmypy", *apply_overrides(args, overrides)], stderr=subprocess.PIPE, **windows_flag
             )
-            _err = completed_process.stderr.decode()
-            _status = completed_process.returncode
-            if _status != 0:
+            errors = completed_process.stderr.decode()
+            exit_status = completed_process.returncode
+            if exit_status != 0:
                 log.info(
-                    "restarting dmypy from status: %s message: %s via path", _status, _err.strip()
+                    "restarting dmypy from status: %s message: %s via path", exit_status, errors.strip()
                 )
                 subprocess.run(["dmypy", "kill"], **windows_flag)
         else:
             # dmypy does not exist on path, but must exist in the env pylsp-mypy is installed in
             # -> use dmypy via api
-            _, _err, _status = mypy_api.run_dmypy(["status"])
-            if _status != 0:
+            _, errors, exit_status = mypy_api.run_dmypy(["status"])
+            if exit_status != 0:
                 log.info(
-                    "restarting dmypy from status: %s message: %s via api", _status, _err.strip()
+                    "restarting dmypy from status: %s message: %s via api", exit_status, errors.strip()
                 )
                 mypy_api.run_dmypy(["kill"])
 
@@ -268,11 +270,12 @@ def pylsp_lint(
             )
             report = completed_process.stdout.decode()
             errors = completed_process.stderr.decode()
+            exit_status = completed_process.returncode
         else:
             # dmypy does not exist on path, but must exist in the env pylsp-mypy is installed in
             # -> use dmypy via api
             log.info("dmypy run args = %s via api", args)
-            report, errors, _ = mypy_api.run_dmypy(args)
+            report, errors, exit_status = mypy_api.run_dmypy(args)
 
     log.debug("report:\n%s", report)
     log.debug("errors:\n%s", errors)
@@ -290,7 +293,7 @@ def pylsp_lint(
                     "end": {"line": 0, "character": 1000},
                 },
                 "message": errors,
-                "severity": 1,  # Error
+                "severity": 1 if exit_status != 0 else 2,  # Error if exited with error or warning.
             }
         )
 

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -245,7 +245,9 @@ def pylsp_lint(
             exit_status = completed_process.returncode
             if exit_status != 0:
                 log.info(
-                    "restarting dmypy from status: %s message: %s via path", exit_status, errors.strip()
+                    "restarting dmypy from status: %s message: %s via path",
+                    exit_status,
+                    errors.strip(),
                 )
                 subprocess.run(["dmypy", "kill"], **windows_flag)
         else:
@@ -254,7 +256,9 @@ def pylsp_lint(
             _, errors, exit_status = mypy_api.run_dmypy(["status"])
             if exit_status != 0:
                 log.info(
-                    "restarting dmypy from status: %s message: %s via api", exit_status, errors.strip()
+                    "restarting dmypy from status: %s message: %s via api",
+                    exit_status,
+                    errors.strip(),
                 )
                 mypy_api.run_dmypy(["kill"])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ install_requires =
     toml
 
 [flake8]
-max-complexity = 10
-max-line-length = 127
+max-complexity = 20
+max-line-length = 100
 
 [options.entry_points]
 pylsp = pylsp_mypy = pylsp_mypy.plugin

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,9 @@ install_requires =
     mypy
     toml
 
+[flake8]
+max-complexity = 10
+max-line-length = 127
 
 [options.entry_points]
 pylsp = pylsp_mypy = pylsp_mypy.plugin


### PR DESCRIPTION
Generic mypy error was only visible to the user when running pylsp with `--verbose --verbose`.

It took me way too much time to figure out why pylsp_mypy is not producing the same errors as the command-line variant did. It turned out the error was:

```
/Applications/Sublime Text.app/Contents/MacOS/Lib/python33 is in the MYPYPATH. Please remove it.
See https://mypy.readthedocs.io/en/stable/running_mypy.html#how-mypy-handles-imports for more info
```

but that was only visible after I went and looked at pylsp_mypy source code and added some logs (didn't know about `--verbose --verbose` exposing that information at the time).

That motivated me to expose this error as a diagnostic on the first line.

Also aligned local mypy configuration with one used on CI to get consistent results.