### PR TITLE
Remove stray output from dmypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
     hooks:
       - id: rst-linter
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -253,7 +253,7 @@ def get_diagnostics(
             # -> use mypy on path
             log.info("executing mypy args = %s on path", args)
             completed_process = subprocess.run(
-                ["mypy", *args], stdout=subprocess.PIPE, stderr=subprocess.PIPE, **windows_flag
+                ["mypy", *args], capture_output=True, **windows_flag
             )
             report = completed_process.stdout.decode()
             errors = completed_process.stderr.decode()
@@ -275,7 +275,7 @@ def get_diagnostics(
             # -> use dmypy on path
             completed_process = subprocess.run(
                 ["dmypy", "--status-file", dmypy_status_file, "status"],
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 **windows_flag,
             )
             errors = completed_process.stderr.decode()
@@ -287,7 +287,9 @@ def get_diagnostics(
                     errors.strip(),
                 )
                 subprocess.run(
-                    ["dmypy", "--status-file", dmypy_status_file, "restart"], **windows_flag
+                    ["dmypy", "--status-file", dmypy_status_file, "restart"],
+                    capture_output=True,
+                    **windows_flag
                 )
         else:
             # dmypy does not exist on path, but must exist in the env pylsp-mypy is installed in
@@ -310,7 +312,7 @@ def get_diagnostics(
             # -> use mypy on path
             log.info("dmypy run args = %s via path", args)
             completed_process = subprocess.run(
-                ["dmypy", *args], stdout=subprocess.PIPE, stderr=subprocess.PIPE, **windows_flag
+                ["dmypy", *args], capture_output=True, **windows_flag
             )
             report = completed_process.stdout.decode()
             errors = completed_process.stderr.decode()

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -252,9 +252,7 @@ def get_diagnostics(
             # mypy exists on path
             # -> use mypy on path
             log.info("executing mypy args = %s on path", args)
-            completed_process = subprocess.run(
-                ["mypy", *args], capture_output=True, **windows_flag
-            )
+            completed_process = subprocess.run(["mypy", *args], capture_output=True, **windows_flag)
             report = completed_process.stdout.decode()
             errors = completed_process.stderr.decode()
             exit_status = completed_process.returncode
@@ -289,7 +287,7 @@ def get_diagnostics(
                 subprocess.run(
                     ["dmypy", "--status-file", dmypy_status_file, "restart"],
                     capture_output=True,
-                    **windows_flag
+                    **windows_flag,
                 )
         else:
             # dmypy does not exist on path, but must exist in the env pylsp-mypy is installed in

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -223,7 +223,7 @@ def test_option_overrides_dmypy(last_diagnostics_monkeypatch, workspace):
         "--show-column-numbers",
         document.path,
     ]
-    m.assert_called_with(expected, stderr=-1, stdout=-1, **windows_flag)
+    m.assert_called_with(expected, capture_output=True, **windows_flag)
 
 
 def test_dmypy_status_file(tmpdir, last_diagnostics_monkeypatch, workspace):


### PR DESCRIPTION
There shouldn't be any output to stdout as this will mess the message stream when pylsp is running in stdout mode.

Fix #52. 