### PR TITLE
cached lookup of mypy executable/venv based on document.path and workspace

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -9,6 +9,7 @@ Created on Fri Jul 10 09:53:57 2020
 import ast
 import atexit
 import collections
+import json
 import logging
 import os
 import os.path
@@ -17,6 +18,7 @@ import shutil
 import subprocess
 import tempfile
 from configparser import ConfigParser
+from functools import lru_cache
 from pathlib import Path
 from typing import IO, Any, Dict, List, Optional
 
@@ -164,6 +166,23 @@ def pylsp_lint(
         return get_diagnostics(config, workspace, document, settings, is_saved)
 
 
+@lru_cache(maxsize=2000)
+def get_venv_cmd(path: str, workspace: str) -> List[str]:
+    if not shutil.which("get-venv.py"):
+        return []
+    try:
+        p = subprocess.run(
+            ["get-venv.py", json.dumps(dict(cmd=["mypy"], path=path, workspace=workspace))],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return json.loads(p.stdout)["cmd"]  # type: ignore
+    except subprocess.CalledProcessError as e:
+        log.warning("Error calling get-venv.py: %s", str(e))
+        return []
+
+
 def get_diagnostics(
     config: Config,
     workspace: Workspace,
@@ -248,12 +267,15 @@ def get_diagnostics(
         args.extend(["--incremental", "--follow-imports", "silent"])
         args = apply_overrides(args, overrides)
 
-        if shutil.which("mypy"):
+        cmd = get_venv_cmd(str(document.path), str(workspace.root_path))
+        if not cmd and shutil.which("mypy"):
+            cmd = ["mypy"]
+        if cmd:
             # mypy exists on path
             # -> use mypy on path
             log.info("executing mypy args = %s on path", args)
             completed_process = subprocess.run(
-                ["mypy", *args], capture_output=True, **windows_flag, encoding="utf-8"
+                [*cmd, *args], capture_output=True, **windows_flag, encoding="utf-8"
             )
             report = completed_process.stdout
             errors = completed_process.stderr


### PR DESCRIPTION
The general idea here is that Python programmers can probably think of a hundred different ways to dynamically configure which install of mypy gets used and how it gets run. I'm doing this by having `pylsp-mypy` look for a script called `get-venv.py` (which probably needs a different, more general/descriptive name, and/or could potentially have a configurable name/path via standard `python-language-server` config), and if it exists, it calls it with a JSON payload of the document path and workspace path, and processing the output as a simple JSON payload to modify how `mypy` is called.

An example `get-venv.py` script is shown below (a simplified version of my own). In my case, I always have `mypy` installed within the venvs themselves, so the simplest option for me is to use my venv manager to run mypy.

Other people might have different ways of setting up their config dynamically - in most cases I think they would be able to just add more items to the returned list, though in some cases they might end up wishing to modify the full invocation, which currently is not possible because I haven't provided it to the `get-venv.py` script. That would be easy enough to change.

```
#!/usr/bin/env python
import argparse
import json
import os
import typing as ty

POETRY = ("poetry", "run", "mypy")
PIPENV = ("pipenv", "run", "mypy")


def get_correct_invocation(cmd: ty.List[str], path: str, workspace: str = ""):
    assert isinstance(cmd, list), f"Command must be a list of strings but is {cmd}"
    if cmd == ["mypy"]:
        if path.startswith(os.path.expanduser("~/work/COPIES/ds-monorepo/")):
            return dict(cmd=POETRY, path=path, workspace=workspace)
        if path.startswith(os.path.expanduser("~/work/")):
            return dict(cmd=PIPENV, path=path, workspace=workspace)
    return dict(cmd=cmd, path=path, workspace=workspace)


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("json")
    args = json.loads(parser.parse_args().json)

    print(json.dumps(get_correct_invocation(args["cmd"], args["path"], args["workspace"])))


if __name__ == "__main__":
    main()
```
