### PR TITLE
Fix decode error on non-utf8 environments

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -234,9 +234,9 @@ def get_diagnostics(
     global tmpFile
     if live_mode and not is_saved:
         if tmpFile:
-            tmpFile = open(tmpFile.name, "w")
+            tmpFile = open(tmpFile.name, "w", encoding="utf-8")
         else:
-            tmpFile = tempfile.NamedTemporaryFile("w", delete=False)
+            tmpFile = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
         log.info("live_mode tmpFile = %s", tmpFile.name)
         tmpFile.write(document.source)
         tmpFile.close()


### PR DESCRIPTION
Added encoding option when opening the tmpFile.
Maybe Fixes #55 
The bug that shows unnecessary diagnostics like `LSP: mypy: can't decode file 'path/to/file.py': 'utf-8' codec can't decode byte 0x82 in position 52: invalid st...` could be reproduced on Japanese Windows 10 when the file includes multi byte characters.
By default, open() encodes a file in cp932 on my environment.
The mypy causes the error when decode_python_encoding() in util.py tries to decode the tmp file by utf-8 codec. It is the default behavior unless the file encoding comment(e.g. # coding: latin-1) is not written in the code.