### PR TITLE
Add error end functionality

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -91,7 +91,7 @@ def parse_line(line: str, document: Optional[Document] = None) -> Optional[Dict[
         lineno = int(linenoStr or 1) - 1  # 0-based line number
         offset = int(offsetStr or 1) - 1  # 0-based offset
         end_lineno = (int(endlinenoStr) - 1) if endlinenoStr else None
-        end_offset = (int(endoffsetStr) - 1) if endoffsetStr else None
+        end_offset = (int(endoffsetStr)) if endoffsetStr else None
         errno = 2
         if severity == "error":
             errno = 1

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -31,7 +31,10 @@ from pylsp.config.config import Config
 from pylsp.workspace import Document, Workspace
 
 line_pattern = re.compile(
-    r"^(?P<file>.+):(?P<start_line>\d+):(?P<start_col>\d*):(?P<end_line>\d*):(?P<end_col>\d*): (?P<severity>\w+): (?P<message>.+?)(?: +\[(?P<code>.+)\])?$"
+    (
+        r"^(?P<file>.+):(?P<start_line>\d+):(?P<start_col>\d*):(?P<end_line>\d*):(?P<end_col>\d*): "
+        r"(?P<severity>\w+): (?P<message>.+?)(?: +\[(?P<code>.+)\])?$"
+    )
 )
 
 log = logging.getLogger(__name__)

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -30,7 +30,9 @@ from pylsp import hookimpl
 from pylsp.config.config import Config
 from pylsp.workspace import Document, Workspace
 
-line_pattern: str = r"((?:^[a-z]:)?[^:]+):(?:(\d+):)?(?:(\d+):)?(?:(\d+):)?(?:(\d+):)? (\w+): (.*)"
+line_pattern = re.compile(
+    r"^(?P<file>.+):(?P<start_line>\d+):(?P<start_col>\d*):(?P<end_line>\d*):(?P<end_col>\d*): (?P<severity>\w+): (?P<message>.+?)(?: +\[(?P<code>.+)\])?$"
+)
 
 log = logging.getLogger(__name__)
 
@@ -77,40 +79,38 @@ def parse_line(line: str, document: Optional[Document] = None) -> Optional[Dict[
         The dict with the lint data.
 
     """
-    result = re.match(line_pattern, line)
-    if result:
-        file_path, linenoStr, offsetStr, endlinenoStr, endoffsetStr, severity, msg = result.groups()
+    result = line_pattern.match(line)
+    if not result:
+        return None
 
-        if file_path != "<string>":  # live mode
-            # results from other files can be included, but we cannot return
-            # them.
-            if document and document.path and not document.path.endswith(file_path):
-                log.warning("discarding result for %s against %s", file_path, document.path)
-                return None
+    file_path = result["file"]
+    if file_path != "<string>":  # live mode
+        # results from other files can be included, but we cannot return
+        # them.
+        if document and document.path and not document.path.endswith(file_path):
+            log.warning("discarding result for %s against %s", file_path, document.path)
+            return None
 
-        lineno = int(linenoStr or 1) - 1  # 0-based line number
-        offset = int(offsetStr or 1) - 1  # 0-based offset
-        end_lineno = (int(endlinenoStr) - 1) if endlinenoStr else None
-        end_offset = (int(endoffsetStr)) if endoffsetStr else None
-        errno = 2
-        if severity == "error":
-            errno = 1
-        diag: Dict[str, Any] = {
-            "source": "mypy",
-            "range": {
-                "start": {"line": lineno, "character": offset},
-                "end": {"line": end_lineno or lineno, "character": end_offset},
-            },
-            "message": msg,
-            "severity": errno,
-        }
-        if diag["range"]["end"]["character"] is None:
-            if document:
-                word = document.word_at_position(diag["range"]["start"])
-                diag["range"]["end"]["character"] = offset + len(word) if word else offset + 1
+    lineno = int(result["start_line"]) - 1  # 0-based line number
+    offset = int(result["start_col"]) - 1  # 0-based offset
+    end_lineno = int(result["end_line"]) - 1
+    end_offset = int(result["end_col"])  # end is exclusive
 
-        return diag
-    return None
+    severity = result["severity"]
+    if severity not in ("error", "note"):
+        log.warning(f"invalid error severity '{severity}'")
+    errno = 1 if severity == "error" else 3
+
+    return {
+        "source": "mypy",
+        "range": {
+            "start": {"line": lineno, "character": offset},
+            "end": {"line": end_lineno, "character": end_offset},
+        },
+        "message": result["message"],
+        "severity": errno,
+        "code": result["code"],
+    }
 
 
 def apply_overrides(args: List[str], overrides: List[Any]) -> List[str]:
@@ -228,7 +228,7 @@ def get_diagnostics(
     if dmypy:
         dmypy_status_file = settings.get("dmypy_status_file", ".dmypy.json")
 
-    args = ["--show-error-end"]
+    args = ["--show-error-end", "--no-error-summary"]
 
     global tmpFile
     if live_mode and not is_saved:

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -105,11 +105,9 @@ def parse_line(line: str, document: Optional[Document] = None) -> Optional[Dict[
             "severity": errno,
         }
         if diag["range"]["end"]["character"] is None:
-            diag["range"]["end"]["character"] = (
-                offset + len(word)
-                if (document and (word := document.word_at_position(diag["range"]["start"])))
-                else offset + 1
-            )
+            if document:
+                word = document.word_at_position(diag["range"]["start"])
+                diag["range"]["end"]["character"] = offset + len(word) if word else offset + 1
 
         return diag
     return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-lsp-server
-mypy
+mypy >= 0.981
 tomli >= 1.1.0 ; python_version < "3.11"
 black
 pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >= 3.7
 packages = find:
 install_requires =
     python-lsp-server >=1.7.0
-    mypy
+    mypy >= 0.981
     tomli >= 1.1.0 ; python_version < "3.11"
 
 [flake8]

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -66,14 +66,14 @@ def test_plugin(workspace, last_diagnostics_monkeypatch):
     diag = diags[0]
     assert diag["message"] == TYPE_ERR_MSG
     assert diag["range"]["start"] == {"line": 0, "character": 0}
-    assert diag["range"]["end"] == {"line": 0, "character": 8}
+    assert diag["range"]["end"] == {"line": 0, "character": 9}
 
 
 def test_parse_full_line(workspace):
     diag = plugin.parse_line(TEST_LINE)  # TODO parse a document here
     assert diag["message"] == '"Request" has no attribute "id"'
     assert diag["range"]["start"] == {"line": 278, "character": 7}
-    assert diag["range"]["end"] == {"line": 278, "character": 18}
+    assert diag["range"]["end"] == {"line": 278, "character": 19}
 
 
 def test_parse_line_without_end(workspace):

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -20,6 +20,9 @@ DOC_TYPE_ERR = """{}.append(3)
 TYPE_ERR_MSG = '"Dict[<nothing>, <nothing>]" has no attribute "append"'
 
 TEST_LINE = 'test_plugin.py:279:8:279:16: error: "Request" has no attribute "id"  [attr-defined]'
+TEST_LINE_NOTE = (
+    'test_plugin.py:124:1:129:77: note: Use "-> None" if function does not return a value'
+)
 
 windows_flag: Dict[str, int] = (
     {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}  # type: ignore
@@ -80,6 +83,15 @@ def test_parse_full_line(workspace):
     assert diag["range"]["end"] == {"line": 278, "character": 16}
     assert diag["severity"] == 1
     assert diag["code"] == "attr-defined"
+
+
+def test_parse_note_line(workspace):
+    diag = plugin.parse_line(TEST_LINE_NOTE)
+    assert diag["message"] == 'Use "-> None" if function does not return a value'
+    assert diag["range"]["start"] == {"line": 123, "character": 0}
+    assert diag["range"]["end"] == {"line": 128, "character": 77}
+    assert diag["severity"] == 3
+    assert diag["code"] == None
 
 
 def test_multiple_workspaces(tmpdir, last_diagnostics_monkeypatch):

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Dict
 from unittest.mock import Mock
@@ -16,12 +17,9 @@ from pylsp_mypy import plugin
 DOC_URI = f"file:/{Path(__file__)}"
 DOC_TYPE_ERR = """{}.append(3)
 """
-TYPE_ERR_MSG = '"Dict[<nothing>, <nothing>]" has no attribute "append"  [attr-defined]'
+TYPE_ERR_MSG = '"Dict[<nothing>, <nothing>]" has no attribute "append"'
 
-TEST_LINE = 'test_plugin.py:279:8:279:19: error: "Request" has no attribute "id"'
-TEST_LINE_WITHOUT_END = 'test_plugin.py:279:8: error: "Request" has no attribute "id"'
-TEST_LINE_WITHOUT_COL = "test_plugin.py:279: " 'error: "Request" has no attribute "id"'
-TEST_LINE_WITHOUT_LINE = "test_plugin.py: " 'error: "Request" has no attribute "id"'
+TEST_LINE = 'test_plugin.py:279:8:279:16: error: "Request" has no attribute "id"  [attr-defined]'
 
 windows_flag: Dict[str, int] = (
     {"creationflags": subprocess.CREATE_NO_WINDOW} if os.name == "nt" else {}  # type: ignore
@@ -66,48 +64,22 @@ def test_plugin(workspace, last_diagnostics_monkeypatch):
     diag = diags[0]
     assert diag["message"] == TYPE_ERR_MSG
     assert diag["range"]["start"] == {"line": 0, "character": 0}
-    assert diag["range"]["end"] == {"line": 0, "character": 9}
+    # Running mypy in 3.7 produces wrong error ends this can be removed when 3.7 reaches EOL
+    if sys.version_info < (3, 8):
+        assert diag["range"]["end"] == {"line": 0, "character": 1}
+    else:
+        assert diag["range"]["end"] == {"line": 0, "character": 9}
+    assert diag["severity"] == 1
+    assert diag["code"] == "attr-defined"
 
 
 def test_parse_full_line(workspace):
     diag = plugin.parse_line(TEST_LINE)  # TODO parse a document here
     assert diag["message"] == '"Request" has no attribute "id"'
     assert diag["range"]["start"] == {"line": 278, "character": 7}
-    assert diag["range"]["end"] == {"line": 278, "character": 19}
-
-
-def test_parse_line_without_end(workspace):
-    doc = Document(DOC_URI, workspace)
-    diag = plugin.parse_line(TEST_LINE_WITHOUT_END, doc)
-    assert diag["message"] == '"Request" has no attribute "id"'
-    assert diag["range"]["start"] == {"line": 278, "character": 7}
-    assert diag["range"]["end"] == {"line": 278, "character": 13}
-
-
-def test_parse_line_without_col(workspace):
-    doc = Document(DOC_URI, workspace)
-    diag = plugin.parse_line(TEST_LINE_WITHOUT_COL, doc)
-    assert diag["message"] == '"Request" has no attribute "id"'
-    assert diag["range"]["start"] == {"line": 278, "character": 0}
-    assert diag["range"]["end"] == {"line": 278, "character": 1}
-
-
-def test_parse_line_without_line(workspace):
-    doc = Document(DOC_URI, workspace)
-    diag = plugin.parse_line(TEST_LINE_WITHOUT_LINE, doc)
-    assert diag["message"] == '"Request" has no attribute "id"'
-    assert diag["range"]["start"] == {"line": 0, "character": 0}
-    assert diag["range"]["end"] == {"line": 0, "character": 6}
-
-
-@pytest.mark.parametrize("word,bounds", [("", (7, 8)), ("my_var", (7, 13))])
-def test_parse_line_with_context(monkeypatch, word, bounds, workspace):
-    doc = Document(DOC_URI, workspace)
-    monkeypatch.setattr(Document, "word_at_position", lambda *args: word)
-    diag = plugin.parse_line(TEST_LINE_WITHOUT_END, doc)
-    assert diag["message"] == '"Request" has no attribute "id"'
-    assert diag["range"]["start"] == {"line": 278, "character": bounds[0]}
-    assert diag["range"]["end"] == {"line": 278, "character": bounds[1]}
+    assert diag["range"]["end"] == {"line": 278, "character": 16}
+    assert diag["severity"] == 1
+    assert diag["code"] == "attr-defined"
 
 
 def test_multiple_workspaces(tmpdir, last_diagnostics_monkeypatch):
@@ -116,7 +88,7 @@ def foo():
     return
     unreachable = 1
 """
-    DOC_ERR_MSG = "Statement is unreachable  [unreachable]"
+    DOC_ERR_MSG = "Statement is unreachable"
 
     # Initialize two workspace folders.
     folder1 = tmpdir.mkdir("folder1")
@@ -141,6 +113,7 @@ def foo():
     assert len(diags) == 1
     diag = diags[0]
     assert diag["message"] == DOC_ERR_MSG
+    assert diag["code"] == "unreachable"
 
     # Test document in workspace 2 (without mypy.ini configuration)
     doc2 = Document(DOC_URI, ws2, DOC_SOURCE)
@@ -236,6 +209,7 @@ def test_option_overrides_dmypy(last_diagnostics_monkeypatch, workspace):
         "--python-executable",
         "/tmp/fake",
         "--show-error-end",
+        "--no-error-summary",
         document.path,
     ]
     m.assert_called_with(expected, capture_output=True, **windows_flag, encoding="utf-8")
@@ -279,7 +253,7 @@ def foo():
     return
     unreachable = 1
 """
-    DOC_ERR_MSG = "Statement is unreachable  [unreachable]"
+    DOC_ERR_MSG = "Statement is unreachable"
 
     config_sub_paths = [".config"]
 
@@ -305,6 +279,7 @@ def foo():
     assert len(diags) == 1
     diag = diags[0]
     assert diag["message"] == DOC_ERR_MSG
+    assert diag["code"] == "unreachable"
 
 
 def test_config_sub_paths_config_changed(tmpdir, last_diagnostics_monkeypatch):
@@ -313,7 +288,7 @@ def foo():
     return
     unreachable = 1
 """
-    DOC_ERR_MSG = "Statement is unreachable  [unreachable]"
+    DOC_ERR_MSG = "Statement is unreachable"
 
     # Create configuration file for workspace.
     config_dir = tmpdir.mkdir(".config")
@@ -336,3 +311,4 @@ def foo():
     assert len(diags) == 1
     diag = diags[0]
     assert diag["message"] == DOC_ERR_MSG
+    assert diag["code"] == "unreachable"

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -91,7 +91,7 @@ def test_parse_note_line(workspace):
     assert diag["range"]["start"] == {"line": 123, "character": 0}
     assert diag["range"]["end"] == {"line": 128, "character": 77}
     assert diag["severity"] == 3
-    assert diag["code"] == None
+    assert diag["code"] is None
 
 
 def test_multiple_workspaces(tmpdir, last_diagnostics_monkeypatch):


### PR DESCRIPTION
Code change for issue #61.

I also noticed that the field `code` of  [`Diagnositc`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic) is unused but rather errors were parsed in such a way that the mypy error code was included in the diagnostic message. I think this is a bug and am also willing to fix it.