### PR TITLE
Clean up dmypy daemon created in test.

### DIFF
--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -7,6 +7,7 @@ from typing import Dict
 from unittest.mock import Mock
 
 import pytest
+from mypy import api as mypy_api
 from pylsp import _utils, uris
 from pylsp.config.config import Config
 from pylsp.workspace import Document, Workspace
@@ -249,14 +250,17 @@ def test_dmypy_status_file(tmpdir, last_diagnostics_monkeypatch, workspace):
 
     assert not statusFile.exists()
 
-    plugin.pylsp_lint(
-        config=config,
-        workspace=workspace,
-        document=document,
-        is_saved=False,
-    )
+    try:
+        plugin.pylsp_lint(
+            config=config,
+            workspace=workspace,
+            document=document,
+            is_saved=False,
+        )
 
-    assert statusFile.exists()
+        assert statusFile.exists()
+    finally:
+        mypy_api.run_dmypy(["--status-file", str(statusFile), "stop"])
 
 
 def test_config_sub_paths(tmpdir, last_diagnostics_monkeypatch):


### PR DESCRIPTION
There is a sequence of events:

1. When using `dmypy`, a daemon process is forked.
2. When `test_dmypy_status_file` runs (and `dmypy` is not in PATH), this daemon is started from the test process.
3. When `pytest` is run and completes, there is a dangling `pytest` process which is running the daemon.
4. When `pytest` is run by the [nix](https://github.com/NixOS/nix) package manager, I observe the package manager waiting forever for this dangling process to complete.

This commit does a best effort cleanup of the `dmypy` daemon before the test is completed.