### PR TITLE
Fix dmypy crash: The `document.path` isn't needed for dmypy's `run` command

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -257,8 +257,6 @@ def get_diagnostics(
         args.append("--config-file")
         args.append(mypyConfigFile)
 
-    args.append(document.path)
-
     if settings.get("strict", False):
         args.append("--strict")
 
@@ -266,6 +264,8 @@ def get_diagnostics(
     exit_status = 0
 
     if not dmypy:
+        args.append(document.path)
+
         args.extend(["--incremental", "--follow-imports", "silent"])
         args = apply_overrides(args, overrides)
 


### PR DESCRIPTION
Removing it from `dmypy` fixes the following crash:
```
some_full_file_path.py:
    1:1   error   Daemon crashed! ​mypy
                  Traceback (most recent call last):
                    File "mypy/dmypy_server.py", line 230, in serve
                    File "mypy/dmypy_server.py", line 277, in run_command
                    File "mypy/dmypy_server.py", line 345, in cmd_run
                    File "mypy/dmypy_server.py", line 414, in check
                    File "mypy/dmypy_server.py", line 663, in fine_grained_increment_follow_imports
                    File "mypy/server/update.py", line 267, in update
                    File "mypy/server/update.py", line 369, in update_one
                    File "mypy/server/update.py", line 452, in update_module
                    File "mypy/server/update.py", line 881, in propagate_changes_using_dependencies
                    File "mypy/server/update.py", line 1009, in reprocess_nodes
                    File "mypy/semanal_main.py", line 148, in semantic_analysis_for_targets
                    File "mypy/semanal_main.py", line 439, in apply_class_plugin_hooks
                    File "mypy/semanal_main.py", line 475, in apply_hooks_to_class
                    File "mypy/plugins/dataclasses.py", line 851, in dataclass_class_maker_callback
                    File "mypy/plugins/dataclasses.py", line 197, in transform
                    File "mypy/plugins/dataclasses.py", line 449, in collect_attributes
                    File "mypy/plugins/dataclasses.py", line 157, in deserialize
                    File "mypy/plugins/common.py", line 344, in deserialize_and_fixup_type
                    File "mypy/types.py", line 1356, in accept
                    File "mypy/fixup.py", line 209, in visit_instance
                    File "mypy/fixup.py", line 344, in lookup_fully_qualified_typeinfo
                    File "mypy/lookup.py", line 31, in lookup_fully_qualified
                  AssertionError: Cannot find module for SomeClass
```

Mypy version 1.3 but this has been an issue in earlier versions too.

I don't see why one would give the file argument to `dmypy run`. The daemon will detect what files have changed by itself.

