### PR TITLE
add regex pattern matching to exclude documents from type checking

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -218,6 +218,15 @@ def get_diagnostics(
         document.path,
         is_saved,
     )
+    exclude = settings.get("exclude", [])
+    for pattern in exclude:
+        if re.match(pattern, document.path):
+            log.debug(
+                "Not running because %s matches exclude pattern %s",
+                document.path,
+                settings.get("exclude"),
+            )
+            return []
 
     live_mode = settings.get("live_mode", True)
     dmypy = settings.get("dmypy", False)

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -328,3 +328,14 @@ def foo():
     diag = diags[0]
     assert diag["message"] == DOC_ERR_MSG
     assert diag["code"] == "unreachable"
+
+
+def test_exclude_path_match_mypy_not_run(tmpdir, workspace):
+    """When exclude is set in config then mypy should not run for that file."""
+    doc = Document(DOC_URI, workspace, DOC_TYPE_ERR)
+
+    plugin.pylsp_settings(workspace._config)
+    workspace.update_config({"pylsp": {"plugins": {"pylsp_mypy": {"exclude": [doc.path]}}}})
+    diags = plugin.pylsp_lint(workspace._config, workspace, doc, is_saved=False)
+
+    assert not diags


### PR DESCRIPTION
See #67 and also my comments there.

I am unsure if it makes sense to optimize the regex by compiling it when loading the configuration. I am unsure how this will work with settings provides by the LSP directly instead of in a `pylsp-mypy.cfg` or `pyproject.toml`.