### PR TITLE
Catch mypy diagnostics which omit start column/end ranges

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -89,9 +89,7 @@ def parse_line(line: str, document: Optional[Document] = None) -> Optional[Dict[
         The dict with the lint data.
 
     """
-    result = line_pattern.match(line)
-    if not result:
-        result = whole_line_pattern.match(line)
+    result = line_pattern.match(line) or whole_line_pattern.match(line)
 
     if not result:
         return None

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -37,7 +37,7 @@ line_pattern = re.compile(
     )
 )
 
-whole_line_pattern = re.compile( # certain mypy warnings do not report start-end ranges
+whole_line_pattern = re.compile(  # certain mypy warnings do not report start-end ranges
     (
         r"^(?P<file>.+):(?P<start_line>\d+): "
         r"(?P<severity>\w+): (?P<message>.+?)(?: +\[(?P<code>.+)\])?$"
@@ -106,7 +106,6 @@ def parse_line(line: str, document: Optional[Document] = None) -> Optional[Dict[
     offset = int(result.groupdict().get("start_col", 1)) - 1  # 0-based offset
     end_lineno = int(result.groupdict().get("end_line", lineno + 1)) - 1
     end_offset = int(result.groupdict().get("end_col", 1))  # end is exclusive
-
 
     severity = result["severity"]
     if severity not in ("error", "note"):


### PR DESCRIPTION
There are a few mypy diagnostics which currently slip through pylsp-mypy's reporting because even with the `--show-column-numbers` and `--show-error-end` those messages do not include a full column and end range.

A good example is the output of `--warn-unused-ignores`:
```bash
src/MainWindow.py:30: error: Unused "type: ignore[name-defined]" comment  [unused-ignore]
```

This commit adds a second line-regexp that catches mypy diagnostics which only include a starting line but have no column or end marker and maps them to an error in the first column of that line. 