### PR TITLE
Fix plugin for long file paths with projects using mypy pretty formatting

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -231,7 +231,7 @@ def get_diagnostics(
     if dmypy:
         dmypy_status_file = settings.get("dmypy_status_file", ".dmypy.json")
 
-    args = ["--show-error-end", "--no-error-summary"]
+    args = ["--show-error-end", "--no-error-summary", "--no-pretty"]
 
     global tmpFile
     if live_mode and not is_saved:


### PR DESCRIPTION
### What is this change
- Use mypy's `--no-pretty` argument for all runs to ensure that the output is parsable.

### Why is this change needed
- I work on large python projects where file paths can be really long and this plugin doesn't currently work for files with long paths.
- ~~`mypy` will use its "pretty" formatting by default and for very long file paths the output is formatted differently. This plugin's parser does not work for such output. Using the `--no-pretty` works for the parser and appears to be an easier change than updating the parser to support this extra output format.~~ 
^ see latest comment for more accurate description

### Logs reproducing the issue and validating the fix
I pulled these logs from the plugin, they show the issue and validate that my change fixes the issue

```
### Diagnostic logs for long file path without this fix, doesn't work

2023-11-11 15:12:12,387 UTC - DEBUG - pylsp_mypy.plugin - report:
Incompatible types in assignment (expression has type "str", variable has type
"int")  [assignment]
    num: int = "str"
               ^~~~~

2023-11-11 15:09:43,643 UTC - DEBUG - pylsp_mypy.plugin - errors:

2023-11-11 15:12:12,387 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = 'src/site_connect_grantor_service/dependencies/dynamo/grants_table.py:32:12:32:16: error:'
2023-11-11 15:12:12,387 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = 'Incompatible types in assignment (expression has type "str", variable has type'
2023-11-11 15:12:12,387 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = '"int")  [assignment]'
2023-11-11 15:12:12,387 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = '    num: int = "str"'
2023-11-11 15:12:12,387 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = '               ^~~~~'
2023-11-11 15:09:43,693 UTC - INFO - pylsp_mypy.plugin - pylsp-mypy len(diagnostics) = 0


### Diagnostic logs for short file path without this fix, does work

setup.py:5:12:5:16: error: Incompatible types in assignment (expression has
type "str", variable has type "int")  [assignment]
    num: int = "str"
               ^~~~~

2023-11-11 15:15:30,115 UTC - DEBUG - pylsp_mypy.plugin - errors:

2023-11-11 15:15:30,115 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = 'setup.py:5:12:5:16: error: Incompatible types in assignment (expression has'
2023-11-11 15:15:30,116 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = 'type "str", variable has type "int")  [assignment]'
2023-11-11 15:15:30,116 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = '    num: int = "str"'
2023-11-11 15:15:30,116 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = '               ^~~~~'
2023-11-11 15:15:30,116 UTC - INFO - pylsp_mypy.plugin - pylsp-mypy len(diagnostics) = 1


### Diagnostic logs for long file path with this fix, does work

src/site_connect_grantor_service/dependencies/dynamo/grants_table.py:32:12:32:16: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]

2023-11-11 18:19:04,614 UTC - DEBUG - pylsp_mypy.plugin - errors:

2023-11-11 18:19:04,615 UTC - DEBUG - pylsp_mypy.plugin - parsing: line = 'src/site_connect_grantor_service/dependencies/dynamo/grants_table.py:32:12:32:16: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]'
2023-11-11 18:19:04,615 UTC - INFO - pylsp_mypy.plugin - pylsp-mypy len(diagnostics) = 1
```