### PR TITLE
Only require tomli in old Python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-lsp-server
 mypy >= 0.981
-tomli >= 1.1.0
+tomli >= 1.1.0 ; python_version < "3.11"
 black
 pre-commit
 rstcheck

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find:
 install_requires =
     python-lsp-server >=1.7.0
     mypy >= 0.981
-    tomli >= 1.1.0
+    tomli >= 1.1.0 ; python_version < "3.11"
 
 [flake8]
 max-complexity = 20


### PR DESCRIPTION
This partly reverts d3620c6.