### PR TITLE
Run dmypy against the whole workspace

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -292,7 +292,10 @@ def get_diagnostics(
         args.append("--config-file")
         args.append(mypyConfigFile)
 
-    args.append(document.path)
+    if dmypy:
+        args.append(workspace.root_path)
+    else:
+        args.append(document.path)
 
     if settings.get("strict", False):
         args.append("--strict")

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -229,7 +229,7 @@ def test_option_overrides_dmypy(last_diagnostics_monkeypatch, workspace):
         "/tmp/fake",
         "--show-error-end",
         "--no-error-summary",
-        document.path,
+        workspace.root_path,
     ]
     m.assert_called_with(expected, capture_output=True, **windows_flag, encoding="utf-8")
 


### PR DESCRIPTION
Hi, I was trying to figure out why every time I ran dmypy from my cli it would restart dmypy and I came across this weird bug dmypy seems to have where running it with different files makes it blind to errors. (I've created a bug against mypy here https://github.com/python/mypy/issues/16705)

This suggestion is to make it so that pylsp-mypy runs dmypy against the whole workspace. It seems this plugin already ignores errors for different files.
