### PR TITLE
Use relative path when calling dmypy

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -363,6 +363,10 @@ def get_diagnostics(
                 )
                 mypy_api.run_dmypy(["--status-file", dmypy_status_file, "restart"])
 
+        # Use relative path of file
+        filepath_idx = args.index(document.path)
+        args[filepath_idx] = os.path.relpath(document.path)
+
         # run to use existing daemon or restart if required
         args = ["--status-file", dmypy_status_file, "run", "--"] + apply_overrides(args, overrides)
         if shutil.which("dmypy"):


### PR DESCRIPTION
With rdev development environment (ubuntu 22.04), `pylsp-mypy` uses the full filepath when linting with `dmypy`. 

This caused some false negatives when linting with my project where in vim (I use vim-lsp + python-lsp-server), vim-lsp/python-lsp-server says the file was linted with no type errors even though I specifically added a type error. 

## Solution

I've found that making dmypy use a relative path (dmypy runs out of my `venv` local to the code repo) and everything works. 

I've yet to debug further, but this is enough to keep me going for now.
