### PR TITLE
Remove '--follow-imports silent' from mypy args

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -301,7 +301,7 @@ def get_diagnostics(
     exit_status = 0
 
     if not dmypy:
-        args.extend(["--incremental", "--follow-imports", "silent"])
+        args.extend(["--incremental"])
         args = apply_overrides(args, overrides)
 
         if shutil.which("mypy"):


### PR DESCRIPTION
This essentially reverts 83df547c5036116a411688edf016c0d32d788bd4.

The main reason for doing this is that this is not the default option when running `mypy`, which means that (absent other configuration) running `mypy .` and using `pylsp-mypy` will invalidate each others caches, which will cause both things to slow down.

`--follow-imports silent` is also incompatible with `dmypy`, so working around this issue by specifying `follow_imports = 'silent'` in your `pyproject.toml` is a non-starter if you want to use `dmypy`.

Closes #81

This would effectively be a revert to https://github.com/tomv564/pyls-mypy/pull/12.  cc @eliwe.