### PR TITLE
Force not pretty output

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -266,7 +266,7 @@ def get_diagnostics(
     if dmypy:
         dmypy_status_file = settings.get("dmypy_status_file", ".dmypy.json")
 
-    args = ["--show-error-end", "--no-error-summary"]
+    args = ["--show-error-end", "--no-error-summary", "--no-pretty"]
 
     global tmpFile
     if live_mode and not is_saved:


### PR DESCRIPTION
The projects using mypy in CI/CD pipeline usually have `pretty = true` set in their mypy configuration and this breaks the parsing of the output in the plugin itself.

This PR will force the non-pretty output of mypy diagnostics.