### PR TITLE
Allow customization of mypy executable path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,10 @@ Configuration
      - Type
      - Description
      - Default
+   * - ``executable``
+     - ``pylsp.plugins.pylsp_mypy.executable``
+     - ``string``
+     - **Set a custom mypy executable location**. If not set, it will find from the current shell's ``PATH``.
    * - ``live_mode``
      - ``pylsp.plugins.pylsp_mypy.live_mode``
      - ``boolean``

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -301,15 +301,18 @@ def get_diagnostics(
     exit_status = 0
 
     if not dmypy:
+        executable = settings.get("executable", None)
+        if executable is None:
+            executable = shutil.which("mypy")
         args.extend(["--incremental", "--follow-imports", settings.get("follow-imports", "silent")])
         args = apply_overrides(args, overrides)
 
-        if shutil.which("mypy"):
-            # mypy exists on path
-            # -> use mypy on path
+        if executable is not None:
+            # mypy exists on the configured location or path
+            # -> use mypy there
             log.info("executing mypy args = %s on path", args)
             completed_process = subprocess.run(
-                ["mypy", *args], capture_output=True, **windows_flag, encoding="utf-8"
+                [executable, *args], capture_output=True, **windows_flag, encoding="utf-8"
             )
             report = completed_process.stdout
             errors = completed_process.stderr


### PR DESCRIPTION
resolves #95

It follows the same convention of the config naming, "executable", like other pylsp plugins:
https://github.com/python-lsp/python-lsp-ruff/blob/041c695d829239345ee9dd5c1f017311d6725ff0/README.md?plain=1#L84