### PR TITLE
Fix diagnostic line numbers

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -51,7 +51,7 @@ mypyConfigFileMap: Dict[str, Optional[str]] = {}
 
 settingsCache: Dict[str, Dict[str, Any]] = {}
 
-tmpFile: Optional[IO[str]] = None
+tmpFile: Optional[IO[bytes]] = None
 
 # In non-live-mode the file contents aren't updated.
 # Returning an empty diagnostic clears the diagnostic result,
@@ -295,11 +295,11 @@ def get_diagnostics(
     global tmpFile
     if live_mode and not is_saved:
         if tmpFile:
-            tmpFile = open(tmpFile.name, "w", encoding="utf-8", newline="")
+            tmpFile = open(tmpFile.name, "wb")
         else:
-            tmpFile = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8", newline="")
+            tmpFile = tempfile.NamedTemporaryFile("wb", delete=False)
         log.info("live_mode tmpFile = %s", tmpFile.name)
-        tmpFile.write(document.source)
+        tmpFile.write(bytes(document.source, "utf-8"))
         tmpFile.close()
         args.extend(["--shadow-file", document.path, tmpFile.name])
     elif not is_saved and document.path in last_diagnostics:

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -295,9 +295,9 @@ def get_diagnostics(
     global tmpFile
     if live_mode and not is_saved:
         if tmpFile:
-            tmpFile = open(tmpFile.name, "w", encoding="utf-8")
+            tmpFile = open(tmpFile.name, "w", encoding="utf-8", newline="")
         else:
-            tmpFile = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8")
+            tmpFile = tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8", newline="")
         log.info("live_mode tmpFile = %s", tmpFile.name)
         tmpFile.write(document.source)
         tmpFile.close()

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -83,6 +83,24 @@ def test_plugin(workspace, last_diagnostics_monkeypatch):
     assert diag["code"] == "attr-defined"
 
 
+@pytest.mark.parametrize("doc_source", ["a = 1\nb\n", "a = 1\r\nb\r\n"])
+def test_handling_of_line_endings(workspace, last_diagnostics_monkeypatch, doc_source):
+    # setup
+    doc = Document(DOC_URI, workspace, doc_source)
+    plugin.pylsp_settings(workspace._config)
+
+    # run
+    diags = plugin.pylsp_lint(workspace._config, workspace, doc, is_saved=False)
+
+    # assert
+    undefined_name_diags = list(filter(lambda diag: diag["code"] == "name-defined", diags))
+    assert len(undefined_name_diags) == 1
+    diag = undefined_name_diags[0]
+    assert diag["message"] == 'Name "b" is not defined'
+    assert diag["range"]["start"] == {"line": 1, "character": 0}
+    assert diag["range"]["end"] == {"line": 1, "character": 1}
+
+
 def test_parse_full_line(workspace):
     diag = plugin.parse_line(TEST_LINE)  # TODO parse a document here
     assert diag["message"] == '"Request" has no attribute "id"'

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -83,7 +83,7 @@ def test_plugin(workspace, last_diagnostics_monkeypatch):
     assert diag["code"] == "attr-defined"
 
 
-@pytest.mark.parametrize("doc_source", ["a = 1\nb\n", "a = 1\r\nb\r\n"])
+@pytest.mark.parametrize("doc_source", ["a = 1\nb\n", "a = 1\r\nb\r\n", "a = 1\rb\r"])
 def test_handling_of_line_endings(workspace, last_diagnostics_monkeypatch, doc_source):
     # setup
     doc = Document(DOC_URI, workspace, doc_source)


### PR DESCRIPTION
fixes #97 

The plugin reports wrong line number for diagnostics in some cases, due to faulty handling of line endings. See the issue description for more details. The fix is to write the text in binary mode, which prevents any line-ending translation by Python.