### PR TITLE
Don't offer a code action for a diagnostic with no diagnostic "code"

### DIFF
--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -604,6 +604,8 @@ def pylsp_code_actions(
     for diagnostic in context.get("diagnostics", []):
         if diagnostic["source"] != "mypy":
             continue
+        if diagnostic.get("code") is None:
+            continue
         code = diagnostic["code"]
         lineNumberEnd = diagnostic["range"]["end"]["line"]
         line = document.lines[lineNumberEnd]

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -112,7 +112,7 @@ def parse_line(line: str, document: Optional[Document] = None) -> Optional[Dict[
         log.warning(f"invalid error severity '{severity}'")
     errno = 1 if severity == "error" else 3
 
-    return {
+    diag = {
         "source": "mypy",
         "range": {
             "start": {"line": lineno, "character": offset},
@@ -120,8 +120,12 @@ def parse_line(line: str, document: Optional[Document] = None) -> Optional[Dict[
         },
         "message": result["message"],
         "severity": errno,
-        "code": result["code"],
     }
+
+    if result["code"]:
+        diag["code"] = result["code"]
+
+    return diag
 
 
 def apply_overrides(args: List[str], overrides: List[Any]) -> List[str]:
@@ -604,7 +608,7 @@ def pylsp_code_actions(
     for diagnostic in context.get("diagnostics", []):
         if diagnostic["source"] != "mypy":
             continue
-        if diagnostic.get("code") is None:
+        if "code" not in diagnostic:
             continue
         code = diagnostic["code"]
         lineNumberEnd = diagnostic["range"]["end"]["line"]

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -98,7 +98,7 @@ def test_parse_note_line(workspace):
     assert diag["range"]["start"] == {"line": 123, "character": 0}
     assert diag["range"]["end"] == {"line": 128, "character": 77}
     assert diag["severity"] == 3
-    assert diag["code"] is None
+    assert "code" not in diag
 
 
 def test_multiple_workspaces(tmpdir, last_diagnostics_monkeypatch):


### PR DESCRIPTION
Per the lsp spec, a diagnostic code, if one exists, should be a number or a string.  At least one error message (the help message for missing imports) doesn't include a code, so the parse_line function sets it to "None".

When this happens, don't offer a code action for that diagnostic

https://github.com/python-lsp/pylsp-mypy/issues/99