### PR TITLE
Giving `document.path` to dmypy limits the daemon and makes it prone to crash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,11 @@ Configuration
      - ``array`` of ``string`` items
      - **The command to run dmypy**. This is useful if you want to run dmypy in a specific virtual environment. Requires env variable ``PYLSP_MYPY_ALLOW_DANGEROUS_CODE_EXECUTION`` to be set.
      - ``[]``
+   * - ``dmypy_project_wide``
+     - ``pylsp.plugins.pylsp_mypy.dmypy_project_wide``
+     - ``boolean``
+     - **Use dmypy in project**. With this option set to false (default) you're telling the daemon to only check specific file(s) given by PYLSP, rather than checking your entire project. The daemon is still watching for all file changes, but you've limited the scope of that particular check.
+     - false
 
 Both ``mypy_command`` and ``dmypy_command`` could be used by a malicious repo to execute arbitrary code by looking at its source with this plugin active.
 Still users want this feature. For security reasons this is disabled by default. If you really want it and accept the risks set the environment variable ``PYLSP_MYPY_ALLOW_DANGEROUS_CODE_EXECUTION`` in order to activate it.

--- a/pylsp_mypy/plugin.py
+++ b/pylsp_mypy/plugin.py
@@ -320,7 +320,6 @@ def get_diagnostics(
         args.append("--config-file")
         args.append(mypyConfigFile)
 
-    args.append(document.path)
 
     if settings.get("strict", False):
         args.append("--strict")
@@ -331,6 +330,7 @@ def get_diagnostics(
     if not dmypy:
         args.extend(["--incremental", "--follow-imports", settings.get("follow-imports", "silent")])
         args = apply_overrides(args, overrides)
+        args.append(document.path)
 
         mypy_command: List[str] = get_cmd(settings, "mypy")
 
@@ -358,6 +358,9 @@ def get_diagnostics(
         # In either case, reset to fresh state
 
         dmypy_command: List[str] = get_cmd(settings, "dmypy")
+
+        if not settings.get("dmypy_project_wide", False):
+            args.append(document.path)
 
         if dmypy_command:
             # dmypy exists on PATH or was provided by settings


### PR DESCRIPTION
When you use `dmypy run -- file`, you're telling the daemon to only check that specific file, rather than checking your entire project. The daemon is still watching for all file changes, but you've limited the scope of that particular check.

Difference:
- dmypy run (without arguments): Checks your entire project, using the configuration from your mypy.ini/setup.cfg/pyproject.toml
- dmypy run -- file: Only checks the specified file and its direct dependencies

This is helpful in situations where you want a quick check of just one file during development, but it won't give you the complete project-wide type checking that dmypy run provides. The daemon itself maintains a cache and tracks file dependencies regardless of which command you use, but the scope of checking is determined by your command arguments.

Continuation of https://github.com/python-lsp/pylsp-mypy/pull/65 :) It's still problematic for me. Seems like you don't want to change the behaviour so I did a rough attempt to add an option for it. Please advise.

Closes https://github.com/python-lsp/pylsp-mypy/issues/102